### PR TITLE
Fix error when creating duplicate context menu

### DIFF
--- a/background.js
+++ b/background.js
@@ -47,20 +47,23 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   }
 });
 
-// Create context menu on all available menus
-chrome.contextMenus.create({
-  id: CONTEXT_MENU_ID,
-  type: 'normal',
-  title: MUTE_TAB_STR,
-  contexts: ['all'] // Chrome doesn't allow us to add a custom context menu item to the actual tab.
-});
+// Only create listeners if not already set up to prevent error
+if (!chrome.contextMenus.onClicked.hasListeners()) {
+  // Create context menu on all available menus
+  chrome.contextMenus.create({
+    id: CONTEXT_MENU_ID,
+    type: 'normal',
+    title: MUTE_TAB_STR,
+    contexts: ['all'] // Chrome doesn't allow us to add a custom context menu item to the actual tab.
+  });
 
-// Modify the mute state when interacting with the context menu option
-chrome.contextMenus.onClicked.addListener(function (info, tab) {
-  if (info.menuItemId === CONTEXT_MENU_ID) {
-    updateMuteState(tab);
-  }
-});
+  // Modify the mute state when interacting with the context menu option
+  chrome.contextMenus.onClicked.addListener(function (info, tab) {
+    if (info.menuItemId === CONTEXT_MENU_ID) {
+      updateMuteState(tab);
+    }
+  });
+}
 
 // Browser frame icon
 chrome.browserAction.setBadgeBackgroundColor({ color: BADGE_BACKGROUND });


### PR DESCRIPTION
The error `Unchecked runtime.lastError: Cannot create item with duplicate id dc82bba0-dfd0-484d-9782-c8a27c521121` happens when loading the extension on a page that already has the context menu. This patch makes it not re-apply the context menu when it already exists. Tested on Chrome Version 83.0.4103.97 (Official Build) (64-bit).